### PR TITLE
Several refactorings to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
 services:
 # we need docker for building the image and mongo for testing
 - docker
-- mongodb
 
 env:
   - DOCKER_COMPOSE_VERSION=1.23.2
@@ -21,21 +20,25 @@ before_install:
 
 install:
 - docker build -t humanconnection/embed-api:latest .
+- docker-compose up -d # some of the tests need mongodb
 
 script:
-- docker run humanconnection/embed-api:latest yarn run eslint
-- docker-compose run --rm embed-api yarn run mocha # some of the tests need mongodb
+- docker-compose exec embed-api yarn run lint
+- docker-compose exec embed-api yarn run mocha
 
 after_success:
-- if [ $TRAVIS_BRANCH == "master" ] && [ $TRAVIS_EVENT_TYPE == "push" ]; then
-  docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
-  docker push humanconnection/embed-api:latest;
-  wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh &&
-  chmod +x send.sh &&
-  ./send.sh success $WEBHOOK_URL
-  fi
+- wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
+- chmod +x send.sh
+- ./send.sh success $WEBHOOK_URL
 
 after_failure:
 - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
 - chmod +x send.sh
 - ./send.sh failure $WEBHOOK_URL
+
+deploy:
+  - provider: script
+    script: scripts/docker_push.sh
+    on:
+      branch: master
+      tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 
 install:
 - docker build -t humanconnection/embed-api:latest .
-- docker-compose up -d # some of the tests need mongodb
+- docker-compose -f docker-compose.yml up -d # some of the tests need mongodb
 
 script:
 - docker-compose exec embed-api yarn run lint

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,7 @@
+version: "3.7"
+
+services:
+  embed-api:
+    volumes:
+      - .:/var/www
+      - /var/www/node_modules/

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "test": "yarn run eslint && yarn run mocha",
-    "eslint": "eslint src/. test/. --config .eslintrc.json",
+    "lint": "eslint src/. test/. --config .eslintrc.json",
     "start": "node src/",
     "dev": "concurrently 'mongod --dbpath data --quiet &>/dev/null' 'wait-on tcp:27017 && DEBUG=feathers nodemon src/'",
     "dev:debug": "DEBUG=feathers nodemon --inspect src/",

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+docker push humanconnection/embed-api:latest

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -3,7 +3,7 @@ const rp = require('request-promise');
 const url = require('url');
 const app = require('../src/app');
 
-const port = app.get('port') || 3030;
+const port = 3051;
 const getUrl = pathname => url.format({
   hostname: app.get('host') || 'localhost',
   protocol: 'http',

--- a/test/services/embeds.test.js
+++ b/test/services/embeds.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const app = require('../../src/app');
 const service = app.service('embeds');
 
-const port = app.get('port') || 3030;
+const port = 3051;
 
 describe('\'embeds\' service', () => {
   before(function(done) {


### PR DESCRIPTION
* remove obsolete mongodb on host (we use docker-compose)
* run all scripts in docker-compose
* rename script `eslint` to just `lint` by convention
* use docker_push script which is recommended in Travis docs
* use tagged deployments

Regarding the tagged deployments: I'm a little uneasy regarding the
deployments. The last image was pushed 18 days ago. An update to the
image will also trigger a deployment. I want to trigger it manually
with a git tag, it just feels safer to me.